### PR TITLE
replace process.nextTick with setImmediate to allow for I/O processing

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -224,10 +224,10 @@ exports.getAnalysisData = function(modules, excludes, config, cb) {
 				if (cacheEntry.state === 1) {
 					cb(cacheEntry.analysisData);
 				} else {
-					process.nextTick(isComplete);
+					setImmediate(isComplete);
 				}
 			}
-			process.nextTick(isComplete);
+			setImmediate(isComplete);
 		} else {
 			if (config.checkTimestamps === false) {
 				cb(cacheEntry.analysisData);

--- a/lib/zazloptimizer.js
+++ b/lib/zazloptimizer.js
@@ -414,7 +414,7 @@ Optimizer.prototype = {
 			}
 		};
 		var scope = this;
-		process.nextTick(function() {
+		setImmediate(function() {
 			errorCallback = errorCallback || function(state) {
 				response.writeHead(state, {'Content-Type': 'text/html'});
 				response.end("<h1>HTTP " + state + "</h1>");


### PR DESCRIPTION
recursive use of nextTick results in thread starvation using node v0.10.28, with the following warning

`warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.`
